### PR TITLE
Solving issue by separating Views and ViewModels

### DIFF
--- a/WpfTestMultipleValidations/MainWindow.xaml
+++ b/WpfTestMultipleValidations/MainWindow.xaml
@@ -74,7 +74,13 @@
                     <ContentControl Margin="16"
                                     Content="{Binding Content, UpdateSourceTrigger=PropertyChanged, FallbackValue={x:Null}}"
                                     DataContext="{Binding SelectedView}"
-                                    DataContextChanged="OnSelectedViewChanged" />
+                                    DataContextChanged="OnSelectedViewChanged">
+                        <ContentControl.Resources>
+                            <DataTemplate DataType="{x:Type viewModels1:ChildView1ViewModel}">
+                                <views:ChildView1 />
+                            </DataTemplate>
+                        </ContentControl.Resources>
+                    </ContentControl>
                 </ScrollViewer>
 
             </Grid>

--- a/WpfTestMultipleValidations/ViewModels/ChildView1ViewModel.cs
+++ b/WpfTestMultipleValidations/ViewModels/ChildView1ViewModel.cs
@@ -1,0 +1,5 @@
+﻿namespace WpfTestMultipleValidations.ViewModels;
+
+public class ChildView1ViewModel : ViewModelBase
+{
+}

--- a/WpfTestMultipleValidations/ViewModels/MainWindowViewModel.cs
+++ b/WpfTestMultipleValidations/ViewModels/MainWindowViewModel.cs
@@ -16,7 +16,7 @@ public class MainWindowViewModel : ViewModelBase
     {
         MenuItems = new ObservableCollection<ViewItem>(new[]
         {
-            new ViewItem("Child 1", new ChildView1(), PackIconKind.TestTube),
+            new ViewItem("Child 1", new ChildView1ViewModel(), PackIconKind.TestTube),
             new ViewItem("texts", new TextBoxesView("from navigation pane"), PackIconKind.Cogs),
         });
     }

--- a/WpfTestMultipleValidations/ViewModels/ViewItem.cs
+++ b/WpfTestMultipleValidations/ViewModels/ViewItem.cs
@@ -6,12 +6,12 @@ namespace Eol.UI.Wpf.ViewModels;
 
 public class ViewItem
 {
-    public FrameworkElement Content { get; }
+    public object Content { get; }
 
     public string Name { get; }
     public PackIconKind? IconKind { get; }
 
-    public ViewItem(string name, FrameworkElement contentType, PackIconKind? iconKind = null)
+    public ViewItem(string name, object contentType, PackIconKind? iconKind = null)
     {
         Name = name;
         IconKind = iconKind;


### PR DESCRIPTION
This "solves" the issue you're seeing by sticking to the MVVM paradigm. The `MainWindowViewModel` should not create views for its nested content, it should create view models and then let the view decide on how to visualize those.

The change is only applied for `ChildView1` to show the approach. The `ViewItem.Content` property was changed to `object` instead of `FrameworkElement` because it needs to represent a `ViewModel` (I used `object` to avoid having to refactor the whole thing, ideally you should use something like the `ViewModelBase` base type).

In the `MainWindow.xaml` I then create a `DataTemplate` which essentially tells the UI that content of type `ChildView1ViewModel` should be rendered using a `ChildView1` user control.